### PR TITLE
Wrap single arg of function type as same as in other definitions.

### DIFF
--- a/_includes/signatures/map.md
+++ b/_includes/signatures/map.md
@@ -1,5 +1,5 @@
 ~~~ scala
 trait Collection[A] {
-  def map[B](f: A => B): Collection[B]
+  def map[B](f: (A) => B): Collection[B]
 }
 ~~~


### PR DESCRIPTION
Only this file uses `A => B` notation, but all other files uses `(A) => B`.

Though I personally prefer shorter `A => B`,  I agree that function types should be written in similar fasion: always use parenthesis around arguments like `(A) => B`, `(A, B) => C` or `(A, B, C) => D`.
