### PR TITLE
Add empty case on reduce

### DIFF
--- a/_en/functions/reduce.md
+++ b/_en/functions/reduce.md
@@ -9,3 +9,7 @@ name: reduce
 `reduce` applies the binary operator `op` to pairs of elements in this collection until the final result is calculated.
 
 @include [figure.html source="images/reduce.svg" desc="Diagram of the function reduce"]
+
+On empty collections this function throws an `UnsupportedOperationException` exception.
+
+@include [figure.html source="images/reduce.2.svg" desc="Diagram of the function reduce"]

--- a/_es/functions/reduce.md
+++ b/_es/functions/reduce.md
@@ -9,3 +9,7 @@ name: reduce
 `reduce` aplica el operador binario `op` a pares de elementos de esta colección hasta que el resultado final es calculado.
 
 @include [figure.html source="../images/reduce.svg" desc="Diagrama de la función reduce"]
+
+En colecciones vacías esta función lanza una excepción `UnsupportedOperationException`.
+
+@include [figure.html source="../images/reduce.2.svg" desc="Diagrama de la función reduceLeft"]

--- a/images/reduce.2.tex
+++ b/images/reduce.2.tex
@@ -1,0 +1,6 @@
+---
+---
+
+\node (A) [empty collection];
+\draw [throw ->] (A.south) -- +(0, -1)
+    node [exception=UnsupportedOperationException, below];


### PR DESCRIPTION
Add a description to `reduce` regarding empty case as same as so in `reduceLeft` & `reduceRight`, so that reader can know what happens if `reduce` is invoked on empty collection.

`reduceOption` already has a description.