### PR TITLE
Correct mapConserve description and signature.

### DIFF
--- a/_en/functions/mapConserve.md
+++ b/_en/functions/mapConserve.md
@@ -6,6 +6,7 @@ name: mapConserve
 
 @include [signatures/mapConserve.md]
 
-`mapConserve` creates a `List` using as elements the results obtained from applying the function `f` to each element of this collection and also preserving its parameterized type.
+`mapConserve` creates a `List` using as elements the results obtained from applying the function `f` to each element of this collection.
+It returns this collection if `f` maps all elements to themselves (as determined by `eq`) 
 
 @include [figure.html source="images/mapConserve.svg" desc="Diagram of the function mapConserve"]

--- a/_includes/signatures/mapConserve.md
+++ b/_includes/signatures/mapConserve.md
@@ -1,5 +1,5 @@
 ~~~ scala
 trait List[A] {
-  def mapConserve(f: (A) => A): List[A]
+  def mapConserve[B >: A <: AnyRef](f: (A) => B): List[B]
 }
 ~~~


### PR DESCRIPTION
I think "preserving its parameterized type" is not accurate description, simplification aside.

```scala
val list  = List(Some("a"), Some("b")) // List[Some[String]]
list.mapConserve(identity)             // List[Some[String]] preserved
list.mapConserve(s => Option(s.get))   // List[Option[String]] changed
```

Above example shows mapConserve can accept `A => B` as long as `B` is a super type of `A` .
IIUC, a characteristic of `mapConserve` is that it will return the collection instance itself when all mapped elements `eq` to original.

And, `A` and `B` should be a sub type of `AnyRef`, not `Any`.
So the signature also needs correction.
https://www.scala-lang.org/api/2.13.0/scala/collection/immutable/List.html#mapConserve[B%3E:A%3C:AnyRef](f:A=%3EB):List[B]
I will simplify this to `def mapConserve[B]` if it is too much detail for new readers.