### PR TITLE
Correct Function.unlift.

### DIFF
--- a/_en/functions/unlift.md
+++ b/_en/functions/unlift.md
@@ -6,11 +6,11 @@ name: unlift
 
 @include [signatures/unlift.md]
 
-`unlift` creates an anonymous function that returns the value wrapped with `Some` returned by this partial function.
+`unlift` creates an anonymous partial function that returns the value extracted from `Some` returned by this function.
 
 @include [figure.html source="images/unlift.svg" desc="Diagram of the function unlift"]
 
-If this function returns `None` then the anonymous function will throw a `MatchError` exception.
+If this function returns `None` then the anonymous partial function will throw a `MatchError` exception.
 
 @include [figure.html source="images/unlift.2.svg" desc="Diagram of the function unlift"]
 


### PR DESCRIPTION
I think `Function.unlift` description confuses "this function" and "the returned anonymous partial function".
Ref. https://www.scala-lang.org/api/2.13.0/scala/Function$.html#unlift[T,R](f:T=%3EOption[R]):PartialFunction[T,R]