### PR TITLE
Add keyboard controls to search.

### DIFF
--- a/search.js
+++ b/search.js
@@ -30,6 +30,30 @@ Search.prototype._search = function(query) {
 
 Search.prototype._inputKeyUp = function(e) {
   switch (e.key) {
+    case "Enter":
+    case "Escape":
+    case "ArrowUp":
+    case "ArrowDown":
+    case "Tab":
+    case "Shift":
+      // ignore
+      break;
+    default:
+      this._hideResults();
+      const query = this._input.value.trim().toLowerCase();
+      if (query === "")
+        return;
+      const results = this._search(query);
+      if (results.length > 0) {
+        this._clearResults();
+        results.forEach(result => this._appendResult(result))
+        this._showResults();
+      }
+  }
+}
+
+Search.prototype._inputKeyDown = function(e) {
+  switch (e.key) {
     case "Enter": // Open the selected item
       const link = this._getSelectedResultItem();
       if (link != null) {
@@ -54,27 +78,6 @@ Search.prototype._inputKeyUp = function(e) {
       } else {
         this._move_down();
       }
-      break;
-    case "Shift": // Shift only.
-      // do nothing
-      break;
-    default:
-      this._hideResults();
-      const query = this._input.value.trim().toLowerCase();
-      if (query === "")
-        return;
-      const results = this._search(query);
-      if (results.length > 0) {
-        this._clearResults();
-        results.forEach(result => this._appendResult(result))
-        this._showResults();
-      }
-  }
-}
-
-Search.prototype._inputKeyDown = function(e) {
-  switch (e.key) {
-    case "Tab":
       // Do not trigger browser's default tab (move to focusable item)
       e.preventDefault();
       break;

--- a/search.js
+++ b/search.js
@@ -55,6 +55,9 @@ Search.prototype._inputKeyUp = function(e) {
         this._move_down();
       }
       break;
+    case "Shift": // Shift only.
+      // do nothing
+      break;
     default:
       this._hideResults();
       const query = this._input.value.trim().toLowerCase();

--- a/search.js
+++ b/search.js
@@ -117,7 +117,13 @@ Search.prototype._selectResultItem = function(diff) {
     this._getSelectedResultItem().classList.remove('selected-item');
   }
   this._selected_item_index += diff;
-  this._getSelectedResultItem().classList.add('selected-item');
+  const selectedItem = this._getSelectedResultItem();
+  if (selectedItem != null) {
+    const topPos = selectedItem.offsetTop - 100;
+    selectedItem.classList.add('selected-item');
+    // Scroll inside search results.
+    selectedItem.parentNode.parentNode.scrollTop = topPos;
+  }
 }
 
 Search.prototype._hideResults = function() {

--- a/style.scss
+++ b/style.scss
@@ -150,6 +150,14 @@
     .searchresult__link {
       display: block;
       padding: .5rem 1rem;
+
+      &:focus,
+      &.selected-item {
+        background: rgba(80, 80, 80, 0.1);
+        border-radius: 4px;
+        outline: 0;
+        text-decoration: underline;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR introduces keyboad controls to the search bar.

1. `Escape` to close search. 
2. `Down` or `Tab` to move down in the seached functions, and  `Up` or `Shift+Tab` to move up.
3. `Enter` to open the selected function.

![search-keybinds](https://user-images.githubusercontent.com/127635/60712852-dfa86300-9f52-11e9-8508-0f13dd7d52e5.gif)