### PR TITLE
Associate andThen and compose so that users can find opposite function

### DIFF
--- a/_en/functions/andThen.md
+++ b/_en/functions/andThen.md
@@ -9,3 +9,6 @@ name: andThen
 `andThen` creates an anonymous function that accepts a value and returns the result of applying this function first and then `g` to that value.
 
 @include [figure.html source="images/andThen.svg" desc="Diagram of the andThen function"]
+
+Both `andThen` and [`compose`](./compose) are used to combine other input functions.
+They do the same job but each one swaps the order the other function applies the input functions.

--- a/_en/functions/compose.md
+++ b/_en/functions/compose.md
@@ -9,3 +9,6 @@ name: compose
 `compose` creates an anonymous function that accepts a value and returns the result of applying the function `g` first and then this function to that value.
 
 @include [figure.html source="images/compose.svg" desc="Diagram of the compose function"]
+
+Both [`andThen`](./andThen) and `compose` are used to combine other input functions.
+They do the same job but each one swaps the order the other function applies the input functions.

--- a/_es/functions/andThen.md
+++ b/_es/functions/andThen.md
@@ -9,3 +9,6 @@ name: andThen
 `andThen` crea una función anónima que acepta un valor y devuelve el resultado de aplicar a este valor esta función primero y luego `g`.
 
 @include [figure.html source="../images/andThen.svg" desc="Diagrama de la función andThen"]
+
+Tanto `andThen` como [`compose`](./compose) se utilizan para combinar otras funciones de entrada.
+Hacen el mismo trabajo pero cada uno intercambia el orden en que la otra función aplica las funciones de entrada.

--- a/_es/functions/compose.md
+++ b/_es/functions/compose.md
@@ -9,3 +9,6 @@ name: compose
 `compose` crea una función anónima que acepta un valor y devuelve el resultado de aplicar la función `g` primero y luego esta función a dicho valor.
 
 @include [figure.html source="../images/compose.svg" desc="Diagrama de la función compose"]
+
+Tanto [`andThen`](./andThen) como `compose` se utilizan para combinar otras funciones de entrada.
+Hacen el mismo trabajo pero cada uno intercambia el orden en que la otra función aplica las funciones de entrada.

--- a/_ja/functions/andThen.md
+++ b/_ja/functions/andThen.md
@@ -9,3 +9,6 @@ name: andThen
 `andThen` は匿名関数を作成します。その関数は、受け取った値にまずこの関数を適用し、次にその値に `g` を適用した結果を返します。
 
 @include [figure.html source="../images/andThen.svg" desc="関数 andThen の図"]
+
+`andThen` と [`compose`](./compose) は他の入力関数を合成するのに使われます。
+どちらも同じ働きですが、入力関数を他の関数と結合する順序がお互い異なります。

--- a/_ja/functions/compose.md
+++ b/_ja/functions/compose.md
@@ -9,3 +9,6 @@ name: compose
 `compose` は匿名関数を作成します。その関数は、受け取った値に `g` を適用し、次にその値にこの関数を適用した結果を返します。
 
 @include [figure.html source="../images/compose.svg" desc="関数 compose の図"]
+
+[`andThen`](./andThen) と `compose` は他の入力関数を合成するのに使われます。
+どちらも同じ働きですが、入力関数を他の関数と結合する順序がお互い異なります。


### PR DESCRIPTION
These changes will be superseded by #4, but it is good to have as of today.