### PR TITLE
Use parameter name as same as in descriptions.

### DIFF
--- a/_includes/signatures/sliding.md
+++ b/_includes/signatures/sliding.md
@@ -1,5 +1,5 @@
 ~~~ scala
 trait Collection[A] {
-  def sliding(sz: Int, st: Int): Iterator[Collection[A]]
+  def sliding(m: Int, s: Int): Iterator[Collection[A]]
 }
 ~~~


### PR DESCRIPTION
The signature of `sliding` uses `sz` and `st` parameters, but those are `m` and `s` in function descriptions.
This PR correct the signature.

# English (and signature)
![image](https://user-images.githubusercontent.com/127635/60848204-a278f500-a220-11e9-95f1-7bdf2997c774.png)

# Spanish
![image](https://user-images.githubusercontent.com/127635/60848209-a4db4f00-a220-11e9-834a-0e44c24a5159.png)

# Japanese
![image](https://user-images.githubusercontent.com/127635/60848212-a9a00300-a220-11e9-94cd-08c90f3f01e3.png)
