### PR TITLE
Fix Type order in foldRight signature

### DIFF
--- a/_includes/signatures/foldRight.md
+++ b/_includes/signatures/foldRight.md
@@ -1,5 +1,5 @@
 ~~~ scala
 trait Collection[A] {
-  def foldRight[B](z: B)(op: (B, A) => B): B
+  def foldRight[B](z: B)(op: (A, B) => B): B
 }
 ~~~

--- a/_includes/signatures/reduceRight.md
+++ b/_includes/signatures/reduceRight.md
@@ -1,5 +1,5 @@
 ~~~ scala
 trait Collection[A] {
-  def reduceRight[B :> A](op: (B, A) => B): B
+  def reduceRight[B :> A](op: (A, B) => B): B
 }
 ~~~

--- a/_includes/signatures/reduceRightOption.md
+++ b/_includes/signatures/reduceRightOption.md
@@ -1,5 +1,5 @@
 ~~~ scala
 trait Collection[A] {
-  def reduceRightOption[B :> A](f: (B, A) => B): Option[B]
+  def reduceRightOption[B :> A](f: (A, B) => B): Option[B]
 }
 ~~~


### PR DESCRIPTION
This PR fixes the order of signature's type in `foldRight` method. 
It seems like it was a copy/paste from `foldLeft`, though [official documentation indicates the correct order](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html#foldRight[B](z:B)(op:(A,B)=%3EB):B).