### PR TITLE
fix japanese

### DIFF
--- a/_en/functions/splitAt.md
+++ b/_en/functions/splitAt.md
@@ -6,6 +6,6 @@ name: splitAt
 
 @include [signatures/splitAt.md]
 
-`splitAt` creates a `Tuple2` with two collections: the first containing all the elements whose index is less or equal than `i` and the other with the rest of elements.
+`splitAt` creates a `Tuple2` with two collections: the first containing all the elements whose index is less than `i` and the other with the rest of elements.
 
 @include [figure.html source="images/splitAt.svg" desc="Diagram of the splitAt function"]

--- a/_ja/functions/splitAt.md
+++ b/_ja/functions/splitAt.md
@@ -7,6 +7,6 @@ name: splitAt
 @include [signatures/splitAt.md]
 
 `splitAt` は、2つのコレクションからなる `Tuple2` を作成します。
-１つ目にはインデックスが `i` より小さいか等しい要素すべて、もう一方には残りの要素が含まれます。
+１つ目にはインデックスが `i` より小さい要素すべて、もう一方には残りの要素が含まれます。
 
 @include [figure.html source="../images/splitAt.svg" desc="関数 splitAt の図"]


### PR DESCRIPTION
This PR fixes the wrong Japanese context of `splitAt` function paragraph.

> before fix

`１つ目にはインデックスが i より小さいか等しい要素すべて、もう一方には残りの要素が含まれます。` means following expample.

```scala
val list = List(1, 2, 3, 4)
val index = 2
list.splitAt(index)

=> (List(1, 2, 3), List(4))
```
But, this is not correct behavior.

> after fix

`１つ目にはインデックスが i より小さい要素すべて、もう一方には残りの要素が含まれます。` means following example.

```scala
val list = List(1, 2, 3, 4)
val index = 2
list.splitAt(index)

=> (List(1, 2), List(3, 4))

```
Actually, element equal to the index is not included in the first List of Tuple.
