### PR TITLE
Fix reverseMap method name

### DIFF
--- a/content/en/functions/reverseMap.md
+++ b/content/en/functions/reverseMap.md
@@ -6,6 +6,6 @@ title: reverseMap
 
 {{< signature reverseMap >}}
 
-`reverse` creates a collection by reversing the order and applying a transformation function `f` to each element.
+`reverseMap` creates a collection by reversing the order and applying a transformation function `f` to each element.
 
 {{< figure src="images/functions/reverseMap.svg" >}}

--- a/content/es/functions/reverseMap.md
+++ b/content/es/functions/reverseMap.md
@@ -6,6 +6,6 @@ title: reverseMap
 
 {{< signature reverseMap >}}
 
-`reverse` crea una colección invirtiendo el orden y aplicando una función de transformación `f` a cada uno de los elementos.
+`reverseMap` crea una colección invirtiendo el orden y aplicando una función de transformación `f` a cada uno de los elementos.
 
 {{< figure src="images/functions/reverseMap.svg" >}}

--- a/content/pt/functions/reverseMap.md
+++ b/content/pt/functions/reverseMap.md
@@ -6,6 +6,6 @@ title: reverseMap
 
 {{< signature reverseMap >}}
 
-`reverse` cria uma coleção revertendo a ordem e aplicando uma função de transformação `f` a cada um dos elementos.
+`reverseMap` cria uma coleção revertendo a ordem e aplicando uma função de transformação `f` a cada um dos elementos.
 
 {{< figure src="images/functions/reverseMap.svg" >}}


### PR DESCRIPTION
I noticed the method name in the `reverseMap.md` files is wrong for all languages except Japanese.